### PR TITLE
Fix CI lint and backend stub

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,11 +1,12 @@
-const express = require('express');
-
+import express from 'express';
 
 const app = express();
+const PORT = process.env.PORT || 3000;
 
-const PORT = e
+app.get('/', (_req, res) => {
+  res.send('API is running');
+});
 
-
-
-
-app.listen()
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/frontend/electron/maiin.ts
+++ b/frontend/electron/maiin.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow } from 'electron';
-import path from 'path';
 
 function createWindow(): void {
   const win = new BrowserWindow({


### PR DESCRIPTION
## Summary
- remove unused path import causing lint failure
- stub an Express server in backend

## Testing
- `npm ci && npm run lint || true && npm test || true` in `backend`
- `npm ci && npm run lint || true && npm test || true` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685345444988832298a2f887d32f0dec